### PR TITLE
percentages were not correctly being calculated for new particles.

### DIFF
--- a/src/base/connectionView.js
+++ b/src/base/connectionView.js
@@ -333,12 +333,16 @@ class ConnectionView extends BaseView {
       this.opacityAttr.needsUpdate = true;
 
       let color = GlobalStyles.threeStyles.colorTraffic.normal;
+
+      let accumulator = 0;
       for (const index in this.object.volumePercentKeysSorted) { // eslint-disable-line no-restricted-syntax, guard-for-in
         const key = this.object.volumePercentKeysSorted[index];
-        if (this.object.volumePercent[key] > rand) {
+        if (this.object.volumePercent[key] + accumulator > rand) {
           color = GlobalStyles.getColorTrafficThree(key);
           break;
         }
+
+        accumulator += this.object.volumePercent[key];
       }
       this.setParticleColor(this.lastParticleIndex, color);
 


### PR DESCRIPTION
We were producing a Random number between 0 and 1 and comparing it to the percentages in order. If the random number was smaller than the percentage for the metric, we would use that metric's color. Unfortunately, that isn't correct.

Here's one example:

```javascript
{
      "source": "INTERNET",
      "target": "us-east-1",
      "metrics": {
        "warning": 50,
        "danger": 50
      }
 }
```

In this case, 50% of the dots would be styled as warning, and 50% would be styled as normal (the default.)

In another example:

```javascript
{
      "source": "INTERNET",
      "target": "us-east-1",
      "metrics": {
        "warning": 95,
        "danger": 5
      }
 }
```

Here, 5% of requests would be styled as danger, 90% of requests would be warning (when the dice is between 5 and 95) and an additional 5% would be styled as normal.

This PR includes the fix for the issue.

I think I ran Lint and I believe it was clean, but please double-check.