### PR TITLE
dns/proxy view

### DIFF
--- a/src/base/connection.js
+++ b/src/base/connection.js
@@ -55,6 +55,8 @@ class Connection extends GraphObject {
 
   update (data) {
     this.metadata = data.metadata || this.metadata;
+    this.annotations = data.annotations || this.annotations;
+
     this.class = data.class || 'normal';
     this.volume = data.metrics ? _.clone(data.metrics) : {};
     if (_.isEmpty(this.volume)) {

--- a/src/base/trafficGraph.js
+++ b/src/base/trafficGraph.js
@@ -224,6 +224,14 @@ class TrafficGraph extends EventEmitter {
     }
   }
 
+  handleIntersectedObjectClick () {
+
+  }
+
+  handleIntersectedObjectDoubleClick () {
+
+  }
+
   showLabels (showLabels) {
     this.displayOptions.showLabels = showLabels;
     // Show labels

--- a/src/dns/dnsConnection.js
+++ b/src/dns/dnsConnection.js
@@ -21,7 +21,7 @@ import DnsConnectionView from './dnsConnectionView';
 class DnsConnection extends Connection {
   constructor (options) {
     super(options);
-    this.graphRenderer = 'global';
+    this.graphRenderer = 'dns';
   }
 
   render () {

--- a/src/dns/dnsConnection.js
+++ b/src/dns/dnsConnection.js
@@ -1,0 +1,32 @@
+/**
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+import Connection from '../base/connection';
+import DnsConnectionView from './dnsConnectionView';
+
+class DnsConnection extends Connection {
+  constructor (options) {
+    super(options);
+    this.graphRenderer = 'global';
+  }
+
+  render () {
+    this.view = new DnsConnectionView(this);
+  }
+}
+
+export default DnsConnection;

--- a/src/dns/dnsConnectionView.js
+++ b/src/dns/dnsConnectionView.js
@@ -31,13 +31,26 @@ function distance (a, b) {
   return Math.sqrt(Math.pow(a.x - b.x, 2) + Math.pow(a.y - b.y, 2));
 }
 
+
+function rotate (point, theta) {
+  return {
+    x: point.x * Math.cos(theta) - point.y * Math.sin(theta),
+    y: point.x * Math.sin(theta) + point.y * Math.cos(theta)
+  };
+}
+
 // Given three points, A B C, find the center of a circle that goes through all three.
 function CalculateCircleCenter (A, B, C) {
   const aSlope = (B.y - A.y) / (B.x - A.x);
   const bSlope = (C.y - B.y) / (C.x - B.x);
 
   if (aSlope === 0 || bSlope === 0) {
-    return CalculateCircleCenter(B, C, A);
+    // rotate the points about origin to retry and then rotate the answer back.
+    // this should avoid div by zero.
+    // we could pick any acute angle here and be garuanteed this will take less than three tries.
+    // i've discovered a clever proof for this, but I don't have room in the margin.
+    const angle = Math.PI / 3;
+    return rotate(CalculateCircleCenter(rotate(A, angle), rotate(B, angle), rotate(C, angle)), -1 * angle);
   }
 
   const center = {};
@@ -66,7 +79,6 @@ class DnsConnectionView extends ConnectionView {
       this.annotationGeometry,
       this.annotationMesh
     ], x => { try { x.dispose(); } catch (e) { Console.log(e); } });
-    // TODO: cleanup annotations.
   }
 
   setParticleLevels () {

--- a/src/dns/dnsConnectionView.js
+++ b/src/dns/dnsConnectionView.js
@@ -1,0 +1,201 @@
+/**
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/* eslint-disable no-mixed-operators */
+
+
+import * as THREE from 'three';
+import _ from 'lodash';
+
+import ConnectionView from '../base/connectionView';
+import GlobalStyles from '../globalStyles';
+
+const Console = console;
+
+function distance (a, b) {
+  return Math.sqrt(Math.pow(a.x - b.x, 2) + Math.pow(a.y - b.y, 2));
+}
+
+// Given three points, A B C, find the center of a circle that goes through all three.
+function CalculateCircleCenter (A, B, C) {
+  const aSlope = (B.y - A.y) / (B.x - A.x);
+  const bSlope = (C.y - B.y) / (C.x - B.x);
+
+  if (aSlope === 0 || bSlope === 0) {
+    return CalculateCircleCenter(B, C, A);
+  }
+
+  const center = {};
+
+  center.x = (aSlope * bSlope * (A.y - C.y) + bSlope * (A.x + B.x) - aSlope * (B.x + C.x)) / (2 * (bSlope - aSlope));
+  center.y = -1 * (center.x - (A.x + B.x) / 2) / aSlope + (A.y + B.y) / 2;
+
+  return center;
+}
+
+class DnsConnectionView extends ConnectionView {
+  constructor (connection) {
+    super(connection, 20000, true);
+
+    this.updatePosition();
+    this.updateVolume();
+
+    this.drawAnnotations();
+  }
+
+  cleanup () {
+    super.cleanup();
+    _.each([
+      this.annotationMaterial,
+      this.annotationTexture,
+      this.annotationGeometry,
+      this.annotationMesh
+    ], x => { try { x.dispose(); } catch (e) { Console.log(e); } });
+    // TODO: cleanup annotations.
+  }
+
+  setParticleLevels () {
+    super.setParticleLevels();
+    this.maxParticleDelay = 10000;
+
+    // After some testing, it's pretty hard to see the difference in density after
+    // 40.  It's still a linear growth curve, but since there is so much overlapping
+    // differences much further than 40 are too difficult to spot
+    this.maxParticleMultiplier = 10;
+  }
+
+  drawAnnotations () {
+    if (!this.object.annotations || this.object.annotations.length === 0) {
+      return;
+    }
+
+    const dx = this.startPosition.x - this.endPosition.x;
+    const dy = this.startPosition.y - this.endPosition.y;
+    const width = Math.floor(Math.sqrt(dx * dx + dy * dy));
+
+    const bump = 40;
+    const headerFontSize = bump * 0.75;
+    const stubRadius = bump; // size of the arrow half-head
+
+    // make sure we are tall enough for all the annotations.
+    const height = this.object.annotations.length * bump * 4;
+
+    const annotationCanvas = this.createCanvas(width, height);
+    this.annotationTexture = new THREE.Texture(annotationCanvas);
+    this.annotationTexture.minFilter = THREE.LinearFilter;
+    this.annotationMaterial = new THREE.MeshBasicMaterial({ map: this.annotationTexture, side: THREE.DoubleSide, transparent: true });
+    this.annotationGeometry = new THREE.PlaneBufferGeometry(annotationCanvas.width, annotationCanvas.height);
+    this.annotationMesh = new THREE.Mesh(this.annotationGeometry, this.annotationMaterial);
+    this.container.add(this.annotationMesh);
+
+    // initially the connection canvas is flat at 0,0 in screen space, so we need to move it and rotate
+    this.annotationMesh.position.set((this.startPosition.x + this.endPosition.x) / 2, (this.startPosition.y + this.endPosition.y) / 2, 0);
+    this.annotationMesh.rotateZ(Math.atan2((this.endPosition.y - this.startPosition.y), (this.endPosition.x - this.startPosition.x)));
+
+
+    const ctx = annotationCanvas.getContext('2d');
+    ctx.clearRect(0, 0, annotationCanvas.width, annotationCanvas.height);
+    ctx.fillStyle = 'rgba(255,255,255,0.125)';
+
+    function drawText (text, style, i) {
+      ctx.fillStyle = style;
+      ctx.font = `700 ${headerFontSize}px 'Source Sans Pro', sans-serif`;
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(text, width / 2, height / 2 - i * bump);
+    }
+
+    function drawCircle (point, startAngle, endAngle, radius, style) {
+      ctx.strokeStyle = style;
+      ctx.lineCap = 'round';
+      ctx.lineWidth = 10;
+      ctx.beginPath();
+      ctx.arc(point.x, point.y, radius, startAngle, endAngle);
+      ctx.stroke();
+    }
+
+    const nodeRadius = this.object.source.getView().radius;
+
+    function drawArrowHalfHead (style, i) {
+      const start = {
+        x: nodeRadius,
+        y: height / 2
+      };
+
+      const end = {
+        x: width - nodeRadius,
+        y: height / 2
+      };
+
+
+        // find the angle perpendicular to the vector between start and end on the clockwise side.
+      let theta = Math.atan((end.y - start.y) / (end.x - start.x));
+      if (start.x <= end.x) {
+        theta -= Math.PI / 2;
+      } else {
+        theta += Math.PI / 2;
+      }
+
+        // find a point perpendicular to the segment between start and end that is `bump` distance away.
+      const offset = {
+        x: (end.x + start.x) / 2 + Math.cos(theta) * bump * i,
+        y: (end.y + start.y) / 2 + Math.sin(theta) * bump * i
+      };
+
+        // get the center of the circle whose arc goes through all three points, its radius and connect the dots
+      const center = CalculateCircleCenter(start, end, offset);
+      const radius = Math.sqrt(Math.pow(start.x - center.x, 2) + Math.pow(start.y - center.y, 2));
+      const startAngle = Math.atan2(start.y - center.y, start.x - center.x);
+      const endAngle = Math.atan2(end.y - center.y, end.x - center.x);
+      drawCircle(center, startAngle, endAngle, radius, style);
+
+        // to draw the arrowhead, we create a small circle opposite the end point from the main arc's center
+      const t2 = Math.atan((end.y - center.y) / (end.x - center.x));
+      let stubCenter = {
+        x: end.x + Math.cos(t2) * stubRadius,
+        y: end.y + Math.sin(t2) * stubRadius
+      };
+
+        // if we didn't actually go on the *opposite* side of the end point, make sure we do that ;)
+      if (distance(stubCenter, center) < distance(end, center)) {
+        stubCenter = {
+          x: end.x - Math.cos(t2) * stubRadius,
+          y: end.y - Math.sin(t2) * stubRadius
+        };
+      }
+
+      const stubAngle = Math.atan2(end.y - stubCenter.y, end.x - stubCenter.x);
+      drawCircle(stubCenter, stubAngle, stubAngle + Math.PI / 4, stubRadius, style);
+    }
+
+    _.each(this.object.annotations, (annotation, index) => {
+      drawArrowHalfHead(GlobalStyles.getColorTraffic(annotation.class), index + 1);
+    });
+
+    _.each(this.object.annotations, (annotation, index) => {
+      if (!annotation.label) {
+        return;
+      }
+
+      drawText(annotation.label, GlobalStyles.getColorTraffic(annotation.class), index + 1);
+    });
+
+    this.annotationTexture.needsUpdate = true;
+  }
+}
+
+export default DnsConnectionView;

--- a/src/dns/dnsNode.js
+++ b/src/dns/dnsNode.js
@@ -1,0 +1,56 @@
+/**
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+import _ from 'lodash';
+
+import Node from '../base/node';
+import DnsNodeView from './dnsNodeView';
+
+class DnsNode extends Node {
+  constructor (node) {
+    super(node, 'dns');
+    this.loaded = false;
+  }
+
+  updateData (totalVolume) {
+    const updated = super.updateData(totalVolume);
+    if (updated) {
+      this.data.globalClassPercents = this.data.globalClassPercents || {};
+      const percentGlobal = this.data.volume / totalVolume;
+      // generate global class percents
+      _.each(this.data.classPercents, (classPercent, key) => {
+        this.data.globalClassPercents[key] = classPercent * percentGlobal;
+      });
+    }
+    return updated;
+  }
+
+  isInteractive () {
+    return false;
+  }
+
+  setContext (context) {
+    super.setContext(context);
+    this.view.updateText();
+  }
+
+  render () {
+    this.view = new DnsNodeView(this);
+  }
+}
+
+export default DnsNode;

--- a/src/dns/dnsNodeView.js
+++ b/src/dns/dnsNodeView.js
@@ -1,0 +1,63 @@
+/**
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+import * as THREE from 'three';
+import GlobalStyles from '../globalStyles';
+import NodeView from '../base/nodeView';
+
+
+class DnsNodeView extends NodeView {
+  constructor (service) {
+    super(service);
+    this.radius = this.object.size;
+    this.innerRadius = this.radius * 0.8;
+    this.meshes.outerBorder = this.addChildElement(NodeView.getOuterBorderGeometry(this.radius), this.borderMaterial);
+    this.meshes.innerCircle = this.addChildElement(NodeView.getInnerCircleGeometry(this.radius), this.innerCircleMaterial);
+    this.meshes.innerCircle.position.setZ(-10);
+
+
+    this.canvasWidth = this.innerRadius * 2;
+    this.canvasHeight = this.canvasWidth;
+
+    this.textCanvas = this.createCanvas(this.canvasWidth, this.canvasHeight);
+    this.textTexture = new THREE.Texture(this.textCanvas);
+    this.textTexture.minFilter = THREE.LinearFilter;
+    this.textTexture.needsUpdate = true;
+
+    this.textMaterial = new THREE.MeshBasicMaterial({ map: this.textTexture, side: THREE.DoubleSide, transparent: true });
+    const text = new THREE.Mesh(new THREE.PlaneBufferGeometry(this.textCanvas.width, this.textCanvas.height), this.textMaterial);
+    this.container.add(text);
+    this.addInteractiveChild(text);
+    text.position.set(0, 0, this.depth + 1);
+
+
+    const textContext = this.textCanvas.getContext('2d');
+    let top = 0;
+    textContext.clearRect(0, 0, this.textCanvas.width, this.textCanvas.height);
+
+    this.headerFontSize = (this.canvasHeight) * 0.2;
+    textContext.fillStyle = GlobalStyles.getColorTraffic(this.object.getClass());
+    textContext.font = `700 ${this.headerFontSize}px 'Source Sans Pro', sans-serif`;
+
+    top += (this.canvasWidth / 2);
+    textContext.fillText(this.object.name, this.textCanvas.width / 2, top);
+
+    this.textTexture.needsUpdate = true;
+  }
+}
+
+export default DnsNodeView;

--- a/src/dns/dnsTrafficGraph.js
+++ b/src/dns/dnsTrafficGraph.js
@@ -1,0 +1,137 @@
+/**
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+import _ from 'lodash';
+
+import DnsConnection from './dnsConnection';
+import DnsNode from './dnsNode';
+import TrafficGraph from '../base/trafficGraph';
+
+const Console = console;
+
+function positionNodes (nodes, dimensions) {
+  const nodesByIndex = _.groupBy(nodes, (n) => {
+    try {
+      return n.metadata.layout.rank;
+    } catch (e) {
+      return Math.Infinity;
+    }
+  });
+
+  const ranks = _.map(Object.keys(nodesByIndex).sort(),
+    (idx) => _.sortBy(nodesByIndex[idx], (node) => {
+      try {
+        return node.metadata.layout.rank;
+      } catch (e) {
+        return Math.Infinity;
+      }
+    })
+  );
+
+  const nodeSize = 100;
+  const availableWidth = dimensions.width;
+  const availableHeight = dimensions.height;
+
+  const rankHeight = availableHeight / ranks.length;
+
+  let rankIndex = 1;
+  const yCenter = (ranks.length + 1) / 2.0;
+
+  _.each(ranks, rank => {
+    const y = -1 * rankHeight * (rankIndex - yCenter);
+
+    const fileWidth = availableWidth / rank.length;
+    let fileIndex = 1;
+
+    const xCenter = (rank.length + 1) / 2.0;
+
+    _.each(rank, node => {
+      node.size = nodeSize;
+      node.loaded = true;
+      node.position = {
+        x: fileWidth * (fileIndex - xCenter),
+        y: y
+      };
+
+      fileIndex++;
+    });
+    rankIndex++;
+  });
+}
+
+class DNSTrafficGraph extends TrafficGraph {
+  constructor (name, mainView, graphWidth, graphHeight) {
+    super(name, mainView, graphWidth, graphHeight, DnsNode, DnsConnection, true);
+    this.linePrecision = 50;
+    this.state = {
+      nodes: [],
+      connections: []
+    };
+    this.contextDivs = {};
+
+    this.dimensions = {
+      width: graphWidth,
+      height: graphHeight
+    };
+
+    this.hasPositionData = true;
+  }
+
+  setState (state) {
+    try {
+      _.each(state.nodes, node => {
+        const existingNodeIndex = _.findIndex(this.state.nodes, { name: node.name });
+        if (existingNodeIndex !== -1) {
+          this.state.nodes[existingNodeIndex] = node;
+        } else {
+          this.state.nodes.push(node);
+        }
+      });
+
+      _.each(state.connections, newConnection => {
+        const existingConnectionIndex = _.findIndex(this.state.connections, { source: newConnection.source, target: newConnection.target });
+        if (existingConnectionIndex !== -1) {
+          this.state.connections[existingConnectionIndex] = newConnection;
+        } else {
+          this.state.connections.push(newConnection);
+        }
+      });
+
+      // update maxVolume
+      // depending on how the data gets fed, we might not have a global max volume.
+      // If we do not, calculate it based on all the second level nodes max volume.
+      //
+      // Just for visual sake, we set the max volume to 150% of the greatest
+      // connection volume. This allows for buffer room for failover traffic to be
+      // more visually dense.
+      let maxVolume = state.maxVolume || 0;
+      if (!maxVolume) {
+        _.each(this.state.nodes, node => {
+          maxVolume = Math.max(maxVolume, node.maxVolume || 0);
+        });
+      }
+      this.state.maxVolume = maxVolume * 1.5;
+    } catch (e) {
+      Console.log(e);
+    }
+
+    positionNodes(this.state.nodes, this.dimensions);
+    super.setState(this.state);
+  }
+}
+
+export default DNSTrafficGraph;

--- a/src/vizceral.js
+++ b/src/vizceral.js
@@ -25,6 +25,7 @@ import GlobalDefinitions from './globalDefinitions';
 import GlobalStyles from './globalStyles';
 import GlobalTrafficGraph from './global/globalTrafficGraph';
 import RegionTrafficGraph from './region/regionTrafficGraph';
+import DnsTrafficGraph from './dns/dnsTrafficGraph';
 
 import RendererUtils from './rendererUtils';
 
@@ -132,7 +133,8 @@ class Vizceral extends EventEmitter {
 
     this.renderers = {
       global: GlobalTrafficGraph,
-      region: RegionTrafficGraph
+      region: RegionTrafficGraph,
+      dns: DnsTrafficGraph
     };
   }
 


### PR DESCRIPTION
Creates a new view type called `dns`, which supports a rank-and-file layout and annotations. We should talk about how to document these view-specific metadata and/or if we should life annotations into connectionView. If we do the latter, we may want to parameterize the line thickness.