### PR TITLE
Limit to 30 FPS

### DIFF
--- a/src/vizceral.js
+++ b/src/vizceral.js
@@ -696,7 +696,10 @@ class Vizceral extends EventEmitter {
   }
 
   animate (time) {
-    requestAnimationFrame(this.animate.bind(this));
+    var that = this;
+    setTimeout(function() {
+      requestAnimationFrame(that.animate.bind(that));
+    }, 1000 / 30);
     this.render(time);
   }
 


### PR DESCRIPTION
Use-case: the machine powering the dashboard showing Vizceral turned into a helicopter in a matter of minutes (I could hear the fans). Even my developer laptop starts sweating, trying to re-render as often as it can. I expect without this change, any machine will always be fully utilized.

Disclaimer: I have minimal experience with WebGL, this is mostly based on reading up on this specific issue (limiting the frame rate) and targeted experiments.