### PR TITLE
Recursive call of dfs sub-function of dfsFas in acyclicFAS.js expects object but is pass a string

### DIFF
--- a/src/layouts/ltrTreeLayout/acyclicFAS.js
+++ b/src/layouts/ltrTreeLayout/acyclicFAS.js
@@ -32,7 +32,7 @@ function dfsFas (graph) {
       if (_.has(stack, edge.target)) {
         fas.push(edge);
       } else {
-        dfs(edge.target);
+        dfs(graph.getNode(edge.target));
       }
     });
     delete stack[node.name];


### PR DESCRIPTION
The `dfs` sub-function of the `dfsFas` function in acyclicFAS.js is called recursively if `edge.target` is not in the `stack` array. The input argument to the recursive calls of `dfs` have been simply `edge.target`, which is a string, but `dfs` actually expects a node object with properties like name.  The `dfs` function in ranker.js uses `graph.getNode()` to get the object from a node name string... so I mimicked this.