### PR TITLE
Added a node size value to the constructors of focusedNode.js and regionNode.js

### DIFF
--- a/src/focused/focusedNode.js
+++ b/src/focused/focusedNode.js
@@ -23,6 +23,7 @@ class FocusedNode extends Node {
   constructor (node) {
     super(node, 'focused');
     this.loaded = true;
+    this.size = node.size || 60;
   }
 
   isInteractive () {

--- a/src/region/regionNode.js
+++ b/src/region/regionNode.js
@@ -22,6 +22,7 @@ class RegionNode extends Node {
   constructor (node) {
     super(node, 'region');
     this.loaded = true;
+    this.size = node.size || 60;
   }
 
   isInteractive () {


### PR DESCRIPTION
I ran into this when I set `layout: "ringCenter"` on a `renderer: "region"` node.  It results in all the nodes being stacked in the center on top of each other.  The issue was that for the `regionNode.js` and `focusedNode.js` don't have a default node size, so in `ringCenterLayout.js` when `recalcaluteOrbitSize` was called `nodeSize` was undefined and `orbitSize` became `NaN` and everything went downhill from there.  Since `ringCenter` worked for `renderer: "global"` I just mimicked what was already in globalNode.js and dnsNode.js.  I arbitrarily picked a size after looking at the sizes set in `globalNode.js` and `dnsNode.js`.  At any rate, adding a default size fixed the issue of using the `ringCenter` layout with at least the `region` renderer.