### PR TITLE
Global node click based on child nodes length

### DIFF
--- a/src/global/globalNode.js
+++ b/src/global/globalNode.js
@@ -26,7 +26,7 @@ class GlobalNode extends Node {
   }
 
   isInteractive () {
-    return !this.isEntryNode();
+    return this.nodes && this.nodes.length > 0;
   }
 
   refreshLoaded () {


### PR DESCRIPTION
It's logical to allow clicking every node in global view. Right now it's available for every node except central node. Better approach would be to allow interaction based on child nodes. If there is no child nodes there is no point in showing empty region view. And if there are any nodes in region view, we're allowing interaction. 