### PR TITLE
Add entryNode property

### DIFF
--- a/src/base/graphObject.js
+++ b/src/base/graphObject.js
@@ -86,10 +86,14 @@ class GraphObject extends EventEmitter {
   }
 
   isClickable () {
-    return this.isInteractive();
+    return this.isInteractive() || this.isDraggable();
   }
 
   isInteractive () {
+    return false;
+  }
+
+  isDraggable () {
     return false;
   }
 

--- a/src/base/node.js
+++ b/src/base/node.js
@@ -23,11 +23,12 @@ import Notices from '../notices';
 const Console = console;
 
 class Node extends GraphObject {
-  constructor (node, renderer) {
+  constructor (node, renderer, entryNode) {
     super();
     this.type = 'node';
     this.update(node);
     this.minimumNoticeLevel = 0;
+    this.entryNode = entryNode;
 
     this.graphRenderer = renderer;
     this.position = this.position || {};
@@ -271,7 +272,12 @@ class Node extends GraphObject {
       && _.every(this.outgoingConnections, connection => connection.source.getName() !== nodeName));
   }
 
+  // If entryNode is specified within graph we're checking if this node is entryNode
+  // else we define entryNode based on amount of incoming and outgoing connections
   isEntryNode () {
+    if (this.entryNode) {
+      return this.name === this.entryNode;
+    }
     return this.incomingConnections.length === 0 && this.outgoingConnections.length > 0;
   }
 

--- a/src/base/trafficGraph.js
+++ b/src/base/trafficGraph.js
@@ -375,9 +375,7 @@ class TrafficGraph extends EventEmitter {
     let updatedState = false;
     if (state && Object.keys(state).length > 0) {
       // it's important to update entryNode when we're switching views
-      if (state.entryNode) {
-        this.entryNode = state.entryNode;
-      }
+      this.entryNode = state.entryNode;
       // If this is the first update, run it, otherwise, only update if it's the current graph
       if (this.current || force) {
         // first, remove nodes that aren't in the new state

--- a/src/base/trafficGraph.js
+++ b/src/base/trafficGraph.js
@@ -670,7 +670,7 @@ class TrafficGraph extends EventEmitter {
     let changed = false;
     _.each(this.nodes, (node) => {
       node.defaultFiltered = !node.hasDefaultVisibleConnections() || !_.every(filters.node, filter => filter.passes(node, filter.defaultValue));
-      const filtered = !node.focused && !node.isEntryNode() && (!node.hasVisibleConnections() || !_.every(filters.node, filter => filter.passes(node, filter.value)));
+      const filtered = !node.focused && (!node.hasVisibleConnections() || !_.every(filters.node, filter => filter.passes(node, filter.value)));
       if (node.filtered !== filtered) {
         node.filtered = filtered;
         changed = true;
@@ -763,8 +763,10 @@ class TrafficGraph extends EventEmitter {
 
     _.each(this.nodes, (n) => { n.filtered = false; });
     _.each(this.connections, (c) => { c.filtered = false; });
-    this._updateConnectionFilters(filters);
-    this._updateNodeFilters(filters);
+    if (Object.keys(this.nodes).length > 1) {
+      this._updateConnectionFilters(filters);
+      this._updateNodeFilters(filters);
+    }
 
     const subsetOfDefaultVisibleNodes = _.every(this.nodes, n => !n.isVisible() || (n.isVisible() && !n.defaultFiltered));
     const subsetOfDefaultVisibleConnections = _.every(this.connections, c => !c.isVisible() || (c.isVisible() && !c.defaultFiltered));

--- a/src/base/trafficGraph.js
+++ b/src/base/trafficGraph.js
@@ -670,7 +670,7 @@ class TrafficGraph extends EventEmitter {
     let changed = false;
     _.each(this.nodes, (node) => {
       node.defaultFiltered = !node.hasDefaultVisibleConnections() || !_.every(filters.node, filter => filter.passes(node, filter.defaultValue));
-      const filtered = !node.focused && (!node.hasVisibleConnections() || !_.every(filters.node, filter => filter.passes(node, filter.value)));
+      const filtered = !node.focused && !node.isEntryNode() && (!node.hasVisibleConnections() || !_.every(filters.node, filter => filter.passes(node, filter.value)));
       if (node.filtered !== filtered) {
         node.filtered = filtered;
         changed = true;

--- a/src/base/trafficGraph.js
+++ b/src/base/trafficGraph.js
@@ -45,12 +45,13 @@ function getPerformanceNow () {
 }
 
 class TrafficGraph extends EventEmitter {
-  constructor (name, mainView, parentGraph, graphWidth, graphHeight, NodeClass, ConnectionClass, Layout) {
+  constructor (name, mainView, parentGraph, graphWidth, graphHeight, NodeClass, ConnectionClass, Layout, entryNode) {
     super();
     this.type = 'default';
     this.name = name;
     this.mainView = mainView;
     this.parentGraph = parentGraph;
+    this.entryNode = entryNode;
     this.nodes = {};
     this.connections = {};
     this.filters = {};
@@ -344,7 +345,9 @@ class TrafficGraph extends EventEmitter {
   }
 
   /**
-   * Return array of entry nodes; effectively nodes that have no incoming connections
+   * Return array of entry nodes,
+   * if entryNode in graph specified we return based on that,
+   * else list of nodes that have no incoming connections
    *
    * @returns {array} array of entry nodes
    */
@@ -394,7 +397,7 @@ class TrafficGraph extends EventEmitter {
           stateNodeMap[stateNode.name] = true;
           let node = this.nodes[stateNode.name];
           if (!node) {
-            node = new this.NodeClass(stateNode);
+            node = new this.NodeClass(stateNode, this.entryNode);
             node.updatePosition(stateNode.position, index);
             this.nodes[stateNode.name] = node;
             this.layoutValid = false;

--- a/src/base/trafficGraph.js
+++ b/src/base/trafficGraph.js
@@ -374,6 +374,10 @@ class TrafficGraph extends EventEmitter {
   setState (state, force, parentState) {
     let updatedState = false;
     if (state && Object.keys(state).length > 0) {
+      // it's important to update entryNode when we're switching views
+      if (state.entryNode) {
+        this.entryNode = state.entryNode;
+      }
       // If this is the first update, run it, otherwise, only update if it's the current graph
       if (this.current || force) {
         // first, remove nodes that aren't in the new state
@@ -739,7 +743,7 @@ class TrafficGraph extends EventEmitter {
 
   _relayout () {
     // Update filters
-    const graph = { nodes: [], connections: [], options: this.layoutOptions };
+    const graph = { nodes: [], connections: [], options: this.layoutOptions, entryNode: this.entryNode };
     let totalNodes = 0;
     let visibleNodes = 0;
 

--- a/src/base/trafficGraph.js
+++ b/src/base/trafficGraph.js
@@ -761,7 +761,9 @@ class TrafficGraph extends EventEmitter {
 
     _.each(this.nodes, (n) => { n.filtered = false; });
     _.each(this.connections, (c) => { c.filtered = false; });
-    if (Object.keys(this.nodes).length > 1) {
+
+    const forceNodesVisible = Object.keys(this.nodes).length > 1;
+    if (forceNodesVisible) {
       this._updateConnectionFilters(filters);
       this._updateNodeFilters(filters);
     }
@@ -780,7 +782,7 @@ class TrafficGraph extends EventEmitter {
       if (useInLayout(node)) {
         graph.nodes.push(node);
       }
-      if (node.connected) {
+      if (node.connected || forceNodesVisible) {
         totalNodes++;
         if (node.isVisible()) { visibleNodes++; }
       }

--- a/src/focused/focusedNode.js
+++ b/src/focused/focusedNode.js
@@ -26,6 +26,10 @@ class FocusedNode extends Node {
     this.loaded = true;
   }
 
+  isDraggable () {
+    return !this.focused;
+  }
+
   isInteractive () {
     return !this.focused;
   }

--- a/src/focused/focusedTrafficGraph.js
+++ b/src/focused/focusedTrafficGraph.js
@@ -22,8 +22,8 @@ import LTRTreeLayout from '../layouts/ltrTreeLayout';
 import TrafficGraph from '../base/trafficGraph';
 
 class FocusedTrafficGraph extends TrafficGraph {
-  constructor (name, mainView, parentGraph, graphWidth, graphHeight, Layout = LTRTreeLayout) {
-    super(name, mainView, parentGraph, graphWidth, graphHeight, FocusedNode, RegionConnection, Layout);
+  constructor (name, mainView, parentGraph, graphWidth, graphHeight, Layout = LTRTreeLayout, entryNode) {
+    super(name, mainView, parentGraph, graphWidth, graphHeight, FocusedNode, RegionConnection, Layout, entryNode);
     this.type = 'focused';
     this.linePrecision = 4;
   }

--- a/src/global/globalNode.js
+++ b/src/global/globalNode.js
@@ -19,9 +19,9 @@ import Node from '../base/node';
 import FocusedNodeView from '../focused/focusedNodeView';
 
 class GlobalNode extends Node {
-  constructor (node) {
+  constructor (node, entryNode) {
     node.size = node.size || 120;
-    super(node, 'global');
+    super(node, 'global', entryNode);
     this.refreshLoaded();
   }
 

--- a/src/global/globalNode.js
+++ b/src/global/globalNode.js
@@ -26,7 +26,8 @@ class GlobalNode extends Node {
   }
 
   isInteractive () {
-    return this.nodes && this.nodes.length > 0;
+    return true;
+    /*     return this.isEntryNode() && this.nodes && this.nodes.length > 0;*/
   }
 
   refreshLoaded () {

--- a/src/global/globalNode.js
+++ b/src/global/globalNode.js
@@ -26,8 +26,11 @@ class GlobalNode extends Node {
   }
 
   isInteractive () {
+    return this.nodes && this.nodes.length > 0;
+  }
+
+  isDraggable () {
     return true;
-    /*     return this.isEntryNode() && this.nodes && this.nodes.length > 0;*/
   }
 
   refreshLoaded () {

--- a/src/global/globalNode.js
+++ b/src/global/globalNode.js
@@ -26,7 +26,7 @@ class GlobalNode extends Node {
   }
 
   isInteractive () {
-    return !this.isEntryNode();
+    return this.nodes && this.nodes.length > 0;
   }
 
   refreshLoaded () {

--- a/src/global/globalTrafficGraph.js
+++ b/src/global/globalTrafficGraph.js
@@ -24,8 +24,8 @@ import RingCenterLayout from '../layouts/ringCenterLayout';
 import TrafficGraph from '../base/trafficGraph';
 
 class GlobalTrafficGraph extends TrafficGraph {
-  constructor (name, mainView, parentGraph, graphWidth, graphHeight, Layout = RingCenterLayout) {
-    super(name, mainView, parentGraph, graphWidth, graphHeight, GlobalNode, GlobalConnection, Layout);
+  constructor (name, mainView, parentGraph, graphWidth, graphHeight, Layout = RingCenterLayout, entryNode) {
+    super(name, mainView, parentGraph, graphWidth, graphHeight, GlobalNode, GlobalConnection, Layout, entryNode);
     this.type = 'global';
 
     this.maxDimension = Math.min(graphWidth, graphHeight);

--- a/src/global/globalTrafficGraph.js
+++ b/src/global/globalTrafficGraph.js
@@ -131,13 +131,13 @@ class GlobalTrafficGraph extends TrafficGraph {
   }
 
   handleIntersectedObjectClick () {
-    if (this.intersectedObject && this.intersectedObject.graphRenderer === 'global') {
+    if (this.intersectedObject && this.intersectedObject.graphRenderer === 'global' && this.intersectedObject.isInteractive()) {
       this.emit('setView', [this.intersectedObject.getName()]);
     }
   }
 
   handleIntersectedObjectDoubleClick () {
-    if (this.intersectedObject && this.intersectedObject.graphRenderer === 'global') {
+    if (this.intersectedObject && this.intersectedObject.graphRenderer === 'global' && this.intersectedObject.isInteractive()) {
       this.emit('setView', [this.intersectedObject.getName()]);
     }
   }

--- a/src/global/globalTrafficGraph.js
+++ b/src/global/globalTrafficGraph.js
@@ -63,7 +63,6 @@ class GlobalTrafficGraph extends TrafficGraph {
   }
 
   setState (state, force) {
-    console.log(state);
     // Remove old nodes
     for (let i = this.state.nodes.length - 1; i >= 0; i--) {
       const newNodeIndex = _.findIndex(state.nodes, { name: this.state.nodes[i].name });

--- a/src/global/globalTrafficGraph.js
+++ b/src/global/globalTrafficGraph.js
@@ -63,6 +63,7 @@ class GlobalTrafficGraph extends TrafficGraph {
   }
 
   setState (state, force) {
+    console.log(state);
     // Remove old nodes
     for (let i = this.state.nodes.length - 1; i >= 0; i--) {
       const newNodeIndex = _.findIndex(state.nodes, { name: this.state.nodes[i].name });
@@ -118,6 +119,9 @@ class GlobalTrafficGraph extends TrafficGraph {
       });
     }
     this.state.maxVolume = maxVolume * 1.5;
+
+    // setting this.state.entryNode to pass it to super.setState
+    this.state.entryNode = state.entryNode;
 
     super.setState(this.state, force);
     this.validateLayout();

--- a/src/layouts/ltrTreeLayout/index.js
+++ b/src/layouts/ltrTreeLayout/index.js
@@ -86,7 +86,7 @@ class LTRTreeLayout {
       };
       layoutWorker.addEventListener('message', layoutWorkerComplete);
 
-      layoutWorker.postMessage({ graph: workerGraph, dimensions: dimensions, entryNode: 'INTERNET', options: graph.options });
+      layoutWorker.postMessage({ graph: workerGraph, dimensions: dimensions, entryNode: graph.entryNode, options: graph.options });
     }
   }
 }

--- a/src/layouts/ltrTreeLayout/ranker.js
+++ b/src/layouts/ltrTreeLayout/ranker.js
@@ -54,7 +54,7 @@ function normalizeRanks (graph) {
   }
 }
 
-function forcePrimaryRankPromotions (graph, entryNodeName) {
+function forcePrimaryRankPromotions (graph, entryNodeName = 'INTERNET') {
   let entryNodes = graph.entryNodes();
   if (entryNodeName) {
     if (entryNodes.includes(entryNodeName)) {
@@ -67,7 +67,7 @@ function forcePrimaryRankPromotions (graph, entryNodeName) {
   }
 }
 
-function forceSecondaryRankPromotions (graph, entryNodeName) {
+function forceSecondaryRankPromotions (graph, entryNodeName = 'INTERNET') {
   let entryNodes = graph.entryNodes();
   if (entryNodeName) {
     if (entryNodes.includes(entryNodeName)) {

--- a/src/layouts/ringCenterLayout.js
+++ b/src/layouts/ringCenterLayout.js
@@ -37,7 +37,7 @@ function positionNodes (nodes, orbitSize) {
   const nodeMap = _.keyBy(nodes, 'name');
   _.each(sortedNodeNames, (nodeName) => {
     const node = nodeMap[nodeName];
-    if (!node.isEntryNode()) {
+    if (!node.isEntryNode() && nodeCount > 0) {
       nodeIndex++;
       updatePosition(node, nodeCount, nodeIndex, orbitSize);
     } else {

--- a/src/region/regionNode.js
+++ b/src/region/regionNode.js
@@ -25,6 +25,10 @@ class RegionNode extends Node {
     this.loaded = true;
   }
 
+  isDraggable () {
+    return true;
+  }
+
   isInteractive () {
     return true;
   }

--- a/src/region/regionTrafficGraph.js
+++ b/src/region/regionTrafficGraph.js
@@ -24,8 +24,9 @@ import TrafficGraph from '../base/trafficGraph';
 const Console = console;
 
 class RegionTrafficGraph extends TrafficGraph {
-  constructor (name, mainView, parentGraph, graphWidth, graphHeight, Layout = LTRTreeLayout) {
-    super(name, mainView, parentGraph, graphWidth, graphHeight, RegionNode, RegionConnection, Layout);
+  constructor (name, mainView, parentGraph, graphWidth, graphHeight, Layout = LTRTreeLayout, entryNode) {
+    super(name, mainView, parentGraph, graphWidth, graphHeight, RegionNode, RegionConnection, Layout, entryNode);
+
     this.type = 'region';
     this.linePrecision = 4;
     this.data = {};

--- a/src/vizceral.js
+++ b/src/vizceral.js
@@ -692,7 +692,7 @@ class Vizceral extends EventEmitter {
       if (intersects.length > 0) {
         if (intersects[0].object.userData.object) {
           userData = intersects[0].object.userData;
-          userData = (userData.object && userData.object.loaded && userData.object.isInteractive()) ? userData : {};
+          userData = (userData.object && userData.object.loaded && (userData.object.isInteractive() || (this.options.allowDraggingOfNodes && userData.object.isDraggable()))) ? userData : {};
         } else {
           Console.warn('Mouse cursor intersected with a visible object that does not have an associated object model. The object should be set at userData.object');
         }

--- a/src/vizceral.js
+++ b/src/vizceral.js
@@ -209,7 +209,7 @@ class Vizceral extends EventEmitter {
           if (graphData.layout && !this.layouts[graphData.layout]) {
             Console.log(`Attempted to create a graph with a layout type that does not exist: ${graphData.layout}. Using default layout for graph type.`);
           }
-          graph = new (this.renderers[graphData.renderer])(graphData.name, mainView, parentGraph, width, height, this.layouts[graphData.layout]);
+          graph = new (this.renderers[graphData.renderer])(graphData.name, mainView, parentGraph, width, height, this.layouts[graphData.layout], graphData.entryNode);
           this._attachGraphHandlers(graph);
           graph.setFilters(this.filters);
           graph.showLabels(this.options.showLabels);


### PR DESCRIPTION
Attempt to fix: #55 and #57 

This PR adds `entryNode` property to every graph. It's string property which should contain name for entry node in given graph.
It was made to allow two way message passing in global view.
Another change is allowing interactivity for all nodes. This solution has problem with entering empty region but it was set to true for every node because every node can have children.
It could be done differently but click and drag uses the same method for interactivity check.
Perfect solution would be to allow clicking only not empty nodes and dragging based on option specified by user but I need some guidance to make that happen if we want this approach.

~~I think there is work left with changing [ltrTreeLayout](https://github.com/Netflix/vizceral/blob/master/src/layouts/ltrTreeLayout/index.js#L89) to new `entryNode` property.~~