### PR TITLE
Giving nodes a default size causes focused node to be too small at detailed node zoom level

### DIFF
--- a/src/focused/focusedChildTrafficGraph.js
+++ b/src/focused/focusedChildTrafficGraph.js
@@ -24,6 +24,7 @@ class FocusedChildTrafficGraph extends FocusedTrafficGraph {
     const thisNode = _.cloneDeep(state);
     delete thisNode.renderer;
     thisNode.focused = true;
+    thisNode.size = 120;
 
     this.layoutOptions = { noRankPromotion: true };
 


### PR DESCRIPTION
Turns out the changes leading to the Vizceral [v4.3.6 ](https://github.com/Netflix/vizceral/commit/1ac921b9603744c90bc659672e7b84ddcd7abac7)release caused the double-clicked node to be drawn too small in the detailed node zoom level view.  Setting the node size of the double-clicked node in `focusedChildTrafficGraph.js` fixes this without altering the node's size in the traffic data.