### PR TITLE
Indexing errors in for-loop with nested splice in ltrTreeGraph.js, plus interesting side effect

### DIFF
--- a/src/layouts/ltrTreeLayout/ltrTreeGraph.js
+++ b/src/layouts/ltrTreeLayout/ltrTreeGraph.js
@@ -69,8 +69,7 @@ Graph.prototype.validateData = function (nodes, edges) {
   }, {});
 
   // Warn if connection connects to a node that doesnt exist
-  let i;
-  for (i in edges) {
+  for (let i = edges.length - 1; i >= 0; i--) {
     if (nodeMap[edges[i].source] === undefined) {
       Console.warn(`Attempted to layout a connection with non-existent source node: ${edges[i].source}.`);
       edges.splice(i, 1);
@@ -86,7 +85,7 @@ Graph.prototype.validateData = function (nodes, edges) {
   }
 
   if (nodes.length > 1) {
-    for (i in nodes) {
+    for (let i = nodes.length - 1; i >= 0; i--) {
       if (!nodeMap[nodes[i].name] || !nodeMap[nodes[i].name].connected) {
         nodes.splice(i, 1);
       }


### PR DESCRIPTION
@jrsquared,

Found a nasty bug in `ltrTreeGraph.js`.  It occurs in two places, [here](https://github.com/Netflix/vizceral/blob/73674723a5e08329455bd8b694c8aff1a556ea01/src/layouts/ltrTreeLayout/ltrTreeGraph.js#L73-L86), and [here](https://github.com/Netflix/vizceral/blob/73674723a5e08329455bd8b694c8aff1a556ea01/src/layouts/ltrTreeLayout/ltrTreeGraph.js#L89-L93).

The for-loop is using the [for...in](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in) style with a nested `splice` call that is/can result in the length of the array changing while it is being iterated over.   This in turn then causes the `for…in` to skip the next element since the length of the array has changed.
```javascript
// Lines 89-93 from ltrTreeGraph.js
for (i in nodes) {
      if (!nodeMap[nodes[i].name] || !nodeMap[nodes[i].name].connected) {
        nodes.splice(i, 1);  // <--- Aah! just changed the length and therefore the indexes!
}
```
I simply reused the safer for loop with a nested splice syntax found elsewhere in the Vizceral code, such as in `globalTrafficGraph.js` at [line 90](https://github.com/Netflix/vizceral/blob/bfc4dfa1cdd6336edbce77e0054bea13988fd09e/src/global/globalTrafficGraph.js#L90), since indexes from end-to-beginning instead of beginning-to-end.

------
### Interesting side effect...
So, I want to show unconnected (orphan) nodes in my usage scenario.   To do this I have made a set of simple changes in `_relayout` of `trafficGraph.js` to no longer use `!node.hasDefaultVisibleConnections()` and `!node.hasVisibleConnections()` so that unconnected nodes would no longer be filtered out, but while this made the unconnected nodes show up in the graph it didn't lay them out.   It just stacked them all at the canvas's center right on top of each other.

**BUT** the code at [Lines 89-93](https://github.com/Netflix/vizceral/blob/73674723a5e08329455bd8b694c8aff1a556ea01/src/layouts/ltrTreeLayout/ltrTreeGraph.js#L89-L93) also removes unconnected nodes, but can't remove all of them since it never "re-checks" the current index, who was removed but was also replaced with the next element (except if it was the very last element of the array).   I find this really confusing, because the code in `ltrTreeGraph.js` executes before the `_relayout` applies does the "filtering", right? maybe? ? ? ?  So how did I ever see any unconnected nodes… unless they just happened to be the next element in the array and where ignored?  Seems pretty unlikely to me to have one orphan get skipped let alone 3 or 4… like I said I’m confused about this.

At any rate, I wasn't sure what or how it was all interacting and since I want orphans I just commented out Lines 88-94 all together and the most unexpected thing resulted!  The orphan nodes were now being laid out!

When those lines are present along with the "filter" changes made in `_relayout`, every unconnected node is laid out at the center of the canvas, stacked one on top of another.  When that chunk of code is commented out (and with the changes in `_relayout` still allowing orphans),  the orphan nodes are laid out, nice and pretty -- no more stacking at the center!   Which I am very glad for as I wasn't looking forward to figuring out why they were ending up stacked in the center.

------
All in all, I figured the `for..in` with nested `splice` was something you might be interested in.  I grep'ed the rest of the code and didn't find any other `for..in`s that are manipulating the thing it is indexing "in".

As always thanks for your support.