### PR TITLE
fix label color issue when traffic color is undefined

### DIFF
--- a/src/base/nodeNameView.js
+++ b/src/base/nodeNameView.js
@@ -93,7 +93,7 @@ class NodeNameView extends BaseView {
     this.resizeCanvas(this.nameCanvas, this.labelWidth, fontSize + 10);
 
     // label color
-    const labelColor = this.highlight ? GlobalStyles.styles.colorTrafficHighlighted[this.object.getClass()] : GlobalStyles.getColorTraffic(this.object.getClass());
+    const labelColor = GlobalStyles.getColorTraffic(this.object.getClass(), this.highlight);
     roundRect(context, 0, 0, this.nameCanvas.width, this.nameCanvas.height, 3, GlobalStyles.styles.colorLabelBorder, labelColor);
     context.fillStyle = GlobalStyles.styles.colorLabelText;
 


### PR DESCRIPTION
This PR contains a simple change:
* fix "when node is highlighted and specified undefined class, label gets black."

![screenshot from 2017-10-15 14-55-50](https://user-images.githubusercontent.com/6854255/31582240-11a2688a-b1b9-11e7-8846-d2fa777960b4.png)
