### PR TITLE
Extend color control when node is selected

### DIFF
--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -96,7 +96,7 @@ class GlobalStyles {
       } else {
         acc[key] = chroma(value).brighten(3).css();
       }
-      // acc[key] = styles.colorTrafficHighlighted && styles.colorTrafficHighlighted[key] ? styles.colorTrafficHighlighted[key] : chroma(value).brighten(3).css();
+
       return acc;
     }, {});
 

--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -96,7 +96,7 @@ class GlobalStyles {
       } else {
         acc[key] = chroma(value).brighten(3).css();
       }
-
+      // acc[key] = styles.colorTrafficHighlighted && styles.colorTrafficHighlighted[key] ? styles.colorTrafficHighlighted[key] : chroma(value).brighten(3).css();
       return acc;
     }, {});
 

--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -86,12 +86,17 @@ class GlobalStyles {
 
   updateStyles (styles) {
     _.merge(this.styles, styles);
-    this.updateComputedStyles();
+    this.updateComputedStyles(styles);
   }
 
-  updateComputedStyles () {
+  updateComputedStyles (styles) {
     this.styles.colorTrafficHighlighted = _.reduce(this.styles.colorTraffic, (acc, value, key) => {
-      acc[key] = chroma(value).brighten(3).css();
+      if (styles && styles.colorTrafficHighlighted && styles.colorTrafficHighlighted[key]) {
+        acc[key] = styles.colorTrafficHighlighted[key];
+      } else {
+        acc[key] = chroma(value).brighten(3).css();
+      }
+
       return acc;
     }, {});
 


### PR DESCRIPTION
As reported here: https://github.com/Netflix/vizceral/issues/102

Having a white background I found it hard to use a color which holds up when the node is selected. By default the color of the node will brightened.
With this PR the user will have the ability the provide a color for highlighted node;

```
this.vizceral.updateStyles({
  colorText: 'rgb(255, 255, 255)', // Text in label
  colorTraffic: {
    normal: 'rgb(0, 75, 111)', // Normal node border, label fill, Transaction fill
    warning: 'rgb(268, 185, 73)',
    danger: 'rgb(184, 36, 36)',
    customClass: '#cccccc'
  },
  colorTrafficHighlighted: {
    customClass: '#333333'
  },
  colorLabelBorder: 'rgba(255, 255, 255, 0)', // Label border
  colorLabelText: 'rgb(255, 255, 255)', // Label text
  colorDonutInternalColor: 'rgb(245, 245, 245)', // Node fill
  colorConnectionLine: 'rgba(20, 20, 20, 0.4)' // Relation line
});

