### PR TITLE
support service owner filtering

### DIFF
--- a/src/base/trafficGraph.js
+++ b/src/base/trafficGraph.js
@@ -230,6 +230,10 @@ class TrafficGraph extends EventEmitter {
       const nodes = filter(this.nodes, (node) => {
         const matchTargets = [node.getName()];
         if (node.displayName) { matchTargets.push(node.displayName); }
+
+        // Allow to filter results based on services' owner/team defined on metadata object.
+        if (node.metadata && node.metadata.owner) { matchTargets.push(node.metadata.owner); }
+
         if (node.nodes) { Array.prototype.push.apply(matchTargets, node.nodes.map(n => n.name)); }
 
         const match = (node === this.highlightedObject || matchTargets.join().toLowerCase().indexOf(searchString.toLowerCase()) !== -1);


### PR DESCRIPTION
I would like to support the ability to filter nodes based on service owner. An optional field named "owner" can be defined in the metadata object and be used when highlighting nodes during search, so that you can search and match for both node names and owner (aka team name), if provided.